### PR TITLE
ADX-958 Add ckanext.validation.allow_invalid_data

### DIFF
--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -661,6 +661,13 @@ def _run_sync_validation(resource_id, local_upload=False, new_resource=True):
 
     if validation['report']:
         report = json.loads(validation['report'])
+    # Check upload of invalid data is allowed
+    allow_invalid_data = bool(t.config.get(
+        'ckanext.validation.allow_invalid_data'
+    ))
+
+    if not report['valid'] and not allow_invalid_data:
+
 
         if not report['valid']:
 
@@ -683,7 +690,7 @@ def _run_sync_validation(resource_id, local_upload=False, new_resource=True):
 
             raise t.ValidationError({
                 u'validation': [report]})
-    else:
-        raise t.ValidationError({
-            'validation': []
-        })
+        else:
+            raise t.ValidationError({
+                'validation': []
+            })


### PR DESCRIPTION
## Description

This PR adds an option to upload resources which failed validation. In some use cases it may be a requirement.

## Testing 
TBD

## Documentation
TBD

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
